### PR TITLE
Export to CSV and scrape current resource requests and limits 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # VSCODE
 .vscode/
+
+# Exported data
+*.yaml
+*.csv

--- a/goldilocks_getter.py
+++ b/goldilocks_getter.py
@@ -3,42 +3,55 @@
 import argparse
 import re
 import requests
-from typing import Dict
-from typing import List
 import yaml
+import csv
+import kubernetes as k8s
+import pandas as pd
 
 from bs4 import BeautifulSoup
-import kubernetes as k8s
 from nested_dict import nested_dict
-import pandas as pd
+
+from typing import Dict
+from typing import List
 
 
 def setup_args():
     parser = argparse.ArgumentParser(
         description="""
-        This script scrapes recommendations from Goldilocks for all SOAs
-        in all namespaces, in all clusters available in the user's .kubeconfig.
+        This script scrapes current resource requirements and recommendations 
+        from Goldilocks for all SOAs in all namespaces, for the provided cluster.
         """
     )
 
     parser.add_argument(
         "-d",
         "--domain",
-        help="domain where goldilocks is installed, e.g. foo.net",
-        required=True
+        help="Domain where goldilocks is installed, e.g. foo.net",
+    )
+    
+    parser.add_argument(
+        "-c",
+        "--cluster",
+        help="Cluster to get the resources of SOAs in a namespace from",
+    )
+    
+    parser.add_argument(
+        "-n",
+        "--namespace",
+        help="Namespace (environment) to get resources for",
+        default="all"
     )
 
     parser.add_argument(
         "-f",
         "--file",
         help="Output file to store recommendations in",
-        required=True
     )
 
     parser.add_argument(
-        "-m",
-        "--mib",
-        help="Use MiB instead of GiB for memory units",
+        "-g",
+        "--gib",
+        help="Use GiB instead of MiB for memory units",
         action="store_true"
     )
 
@@ -59,9 +72,8 @@ def setup_args():
     )
 
     parser.add_argument(
-        "-t",
-        "--test",
-        help="Only collect information from the first cluster to speed up testing",
+        "--csv",
+        help="Output data in CSV format to easily import it in other tools",
         action="store_true"
     )
 
@@ -70,37 +82,13 @@ def setup_args():
     return args
 
 
-def get_clusters(env: str, test: bool = False) -> List[str]:
-    """Gets prod k8s clusters.
-    Uses the user's kubeconfig file to get all clusters available, and then
-    filters to the user's desired environment. If the _ in the call to
-    list_kube_config_contexts() is replaced with a variable, the active context
-    will also be returned.
-
-    Args:
-        env: A filter to be used for startswith() - {prod, stage, test}.
-        test: Only returns the first cluster.
-
-    Raises:
-        Nothing.
-
-    Returns:
-        A list of prod k8s clusters.
-    """
-
-    contexts, _ = k8s.config.list_kube_config_contexts()
-    filtered_contexts = [x["name"] for x in contexts if x["name"].startswith(env)]
-    if test:
-        return filtered_contexts[:1]
-    return filtered_contexts
-
-
-def get_namespaces(cluster: str) -> List[str]:
+def get_namespaces(cluster: str, namespace: str) -> List[str]:
     """Gets namespaces with Goldilocks.
     Gets namespaces from a given k8s cluster that have Goldilocks enabled.
 
     Args:
         cluster: k8s cluster name
+        namepsace: the namespace to get resource requests for
 
     Raises:
         Nothing.
@@ -114,14 +102,53 @@ def get_namespaces(cluster: str) -> List[str]:
             context=cluster
         )
     )
-    namespaces = client.list_namespace()
+    
+    if namespace != "all":
+        return [namespace]
+    
+    namespaces = client.list_namespace(label_selector="goldilocks.fairwinds.com/enabled")
     filtered_namespaces = []
 
     for pod in [x.metadata for x in namespaces.items if x.metadata.labels]:
-        if pod.labels["goldilocks.fairwinds.com/enabled"]:
-            filtered_namespaces.append(pod.name)
+        filtered_namespaces.append(pod.name)
 
     return filtered_namespaces
+
+def get_current_resources(
+    cluster: str,
+    namespace: str,
+) -> Dict[str, k8s.client.V1ResourceRequirements]:
+    """Gets current resource requirements for SOAs in the provided namespace and cluster.
+    Gets current resource requirements for SOAs in the provided namespace and cluster.
+
+    Args:
+        cluster: k8s cluster name
+        namepsace: the namespace to get resource requests for
+
+    Raises:
+        Nothing.
+
+    Returns:
+        A dictionary with cluster/namespace/SOA key and the SOAs' resource requirements.
+    """
+
+    client = k8s.client.AppsV1Api(
+        api_client=k8s.config.new_client_from_config(
+            context=cluster
+        )
+    )
+
+    mega_dict = nested_dict()
+    namespaces = get_namespaces(cluster, namespace)
+
+    print(f"Getting current requirements for SOAs in {cluster}/{namespace}")
+
+    deployments = client.list_namespaced_deployment(namespace=namespace)
+    for deployment in deployments.items:
+        for container in deployment.spec.template.spec.containers:
+            mega_dict[cluster][namespace][deployment.metadata.name] = container.resources
+
+    return mega_dict
 
 
 def get_html(
@@ -144,16 +171,25 @@ def get_html(
         Bytes from Goldilocks.
     """
 
-    # This may need to be adjusted depending on your naming scheme.
-    cluster_name = "-".join(cluster.split("-")[:-1])
-    try:
-        endpoint = f"https://goldilocks-{cluster_name}.{domain}/dashboard/{namespace}"
-        request = requests.get(endpoint)
-    except requests.exceptions.ConnectionError:
-        print(f"Exception raised when connecting to {endpoint}")
-        raise SystemExit
+    # Test multiple hostname from domain separators.
+    # The endpoint should normally be a FQDN (e.g. use a dot).
+    separators = ["-", "."]
 
-    return request.content
+    for index, sep in enumerate(separators):
+        try:
+            endpoint = f"https://goldilocks.{cluster}{sep}{domain}/dashboard/{namespace}"
+
+            print(f"Attempt connecting to {endpoint}")
+            request = requests.get(endpoint)
+            print(f"Successfully connected to {endpoint}")
+
+            return request.content
+        except requests.exceptions.ConnectionError:
+            if index < len(separators):
+                print(f"Failed connecting to {endpoint}")
+            else:
+                print(f"Exception raised when connecting to {endpoint}")
+                raise SystemExit
 
 
 def make_soup(
@@ -219,12 +255,12 @@ def convert_human_readable_to_bytes(human_bytes: str) -> int:
     return int(human_bytes_tuple[0]) * convert_map[human_bytes_tuple[1].lower()]
 
 
-def convert_bytes_to_human_readable(machine_bytes: int, mib: bool = False) -> str:
+def convert_bytes_to_human_readable(machine_bytes: int, gib: bool = False) -> str:
     """Converts bytes to mebibytes or gibibytes.
     Converts bytes (e.g. 1073741824) to human-readable (e.g. 1 [GiB] - unit not included)
 
     Args:
-        mib: Use MiB (True) or GiB (False) for units.
+        gib: Use GiB (True) or MiB (False) for units.
         machine_bytes: An input int of bytes.
 
     Raises:
@@ -234,21 +270,25 @@ def convert_bytes_to_human_readable(machine_bytes: int, mib: bool = False) -> st
         A string of human-readable bytes, e.g. 1 [GiB].
     """
 
-    if mib:
-        multiplicand = 20
-    else:
+    if gib:
         multiplicand = 30
+    else:
+        multiplicand = 20
 
-    return f"{round(machine_bytes, 2)/2**multiplicand}"
+    return f"{int(round(machine_bytes, 2)/2**multiplicand)}"
 
 
-def make_useful_dict(mega_dict: nested_dict) -> nested_dict:
+def make_useful_dict(
+    mega_dict: nested_dict,
+    source: str
+) -> nested_dict:
     """Makes a nested_dict() with useful information.
     Makes a nested_dict() with limits and requests for CPU and memory,
     along with cluster and namespace information.
 
     Args:
         mega_dict: A nested_dict.
+        source: Source of data (html or k8s).
 
     Raises:
         Nothing.
@@ -258,34 +298,68 @@ def make_useful_dict(mega_dict: nested_dict) -> nested_dict:
     """
 
     soa_recs = nested_dict()
-    # First, flatten out a given cluster's items
-    for k, v in mega_dict.items_flat():
-        # Example line for a given SOA:
-        # ['resources:', '  requests:', '    cpu: 108m', '    memory: 5815M', '  limits:', '    cpu: 191m', '    memory: 7134M']
-        line = v.split("\n")
+    if source == "html":
+        # First, flatten out a given cluster's items
+        for k, v in mega_dict.items_flat():
+            # Example line for a given SOA:
+            # ['resources:', '  requests:', '    cpu: 108m', '    memory: 5815M', '  limits:', '    cpu: 191m', '    memory: 7134M']
+            line = v.split("\n")
 
-        # Strip out whitespace and split values out, converting to bytes and dropping millicore unit
-        request_cpu = line[2].split(":")[1].replace(" ", "").replace("m", "")
-        request_mem = line[3].split(":")[1].replace(" ", "")
-        request_mem = convert_human_readable_to_bytes(request_mem)
-        limit_cpu = line[5].split(":")[1].replace(" ", "").replace("m", "")
-        limit_mem = line[6].split(":")[1].replace(" ", "")
-        limit_mem = convert_human_readable_to_bytes(limit_mem)
+            # Strip out whitespace and split values out, converting to bytes and dropping millicore unit
+            request_cpu = line[2].split(":")[1].replace(" ", "").replace("m", "")
+            request_mem = line[3].split(":")[1].replace(" ", "")
+            request_mem = convert_human_readable_to_bytes(request_mem)
+            limit_cpu = line[5].split(":")[1].replace(" ", "").replace("m", "")
+            limit_mem = line[6].split(":")[1].replace(" ", "")
+            limit_mem = convert_human_readable_to_bytes(limit_mem)
 
-        # Fill new nested_dict with values
-        soa_recs[k[0]]["requests"][k[1]][k[2]]["cpu"] = int(request_cpu)
-        soa_recs[k[0]]["requests"][k[1]][k[2]]["memory"] = int(request_mem)
-        soa_recs[k[0]]["limits"][k[1]][k[2]]["cpu"] = int(limit_cpu)
-        soa_recs[k[0]]["limits"][k[1]][k[2]]["memory"] = int(limit_mem)
+            # Fill new nested_dict with values
+            soa_recs[k[0]]["requests"][k[1]][k[2]]["cpu"] = int(request_cpu)
+            soa_recs[k[0]]["requests"][k[1]][k[2]]["memory"] = int(request_mem)
+            soa_recs[k[0]]["limits"][k[1]][k[2]]["cpu"] = int(limit_cpu)
+            soa_recs[k[0]]["limits"][k[1]][k[2]]["memory"] = int(limit_mem)
+    if source == "k8s":
+        # First, flatten out a given cluster's items
+        for k, v in mega_dict.items_flat():
+            # Example line for a given SOA:
+            # ['resources:', '  requests:', '    cpu: 108m', '    memory: 5815M', '  limits:', '    cpu: 191m', '    memory: 7134M']
+
+            # Strip out whitespace and split values out, converting to bytes and dropping millicore unit
+            try:
+                request_cpu = v.requests["cpu"]
+            except KeyError:
+                request_cpu = "0"
+            try:
+                request_mem = v.requests["memory"]
+            except KeyError:
+                request_mem = "0"
+
+            request_mem = convert_human_readable_to_bytes(request_mem)
+
+            try:
+                limit_cpu = v.limits["cpu"]
+            except KeyError:
+                limit_cpu = "0"
+            try:
+                limit_mem = v.limits["memory"]
+            except KeyError:
+                limit_mem = "0"
+            limit_mem = convert_human_readable_to_bytes(limit_mem)
+
+            # Fill new nested_dict with values
+            soa_recs[k[0]]["requests"][k[1]][k[2]]["cpu"] = int(request_cpu.replace('m', ''))
+            soa_recs[k[0]]["requests"][k[1]][k[2]]["memory"] = int(request_mem)
+            soa_recs[k[0]]["limits"][k[1]][k[2]]["cpu"] = int(limit_cpu.replace('m', ''))
+            soa_recs[k[0]]["limits"][k[1]][k[2]]["memory"] = int(limit_mem)
 
     return soa_recs
-
+        
 
 def make_dataframe(
     recs: nested_dict,
     limit_or_rec: str,
-    cluster_list: list,
-    mib: bool
+    cluster: str,
+    gib: bool
 ) -> tuple:
     """Makes a dataframe for each resource type and and fills it out.
     Makes a Pandas dataframe for CPU and memory, and fills it with usable data from Goldilocks.
@@ -293,7 +367,8 @@ def make_dataframe(
     Args:
         recs: A nested_dict containing Goldilocks' recommendations.
         limit_or_rec: {requests, limits} - k8s resource recommendation type.
-        mib: From args.mib - indicates whether to use Gi[B] or Mi[B].
+        cluster: cluster which hosts the environment.
+        gib: From args.gib - indicates whether to use Gi[B] or Mi[B].
 
 
     Raises:
@@ -308,19 +383,25 @@ def make_dataframe(
     cpu_columns = ["namespace", "soa", "millicores"]
     memory_columns = ["namespace", "soa", "size"]
 
-    for cluster in cluster_list:
-        for k, v in recs[cluster][limit_or_rec].items_flat():
-            if "memory" in k:
-                memory_values.append((k[0], k[1], convert_bytes_to_human_readable(v, mib)))
-            elif "cpu" in k:
-                cpu_values.append((k[0], k[1], int(v)))
-            else:
-                print("Error finding recommendations - can you connect to the cluster?")
-                raise SystemExit
+    for k, v in recs[cluster][limit_or_rec].items_flat():
+        if "memory" in k:
+            memory_values.append((k[0], k[1], convert_bytes_to_human_readable(v, gib)))
+        elif "cpu" in k:
+            cpu_values.append((k[0], k[1], v))
+        else:
+            print("Error finding recommendations - can you connect to the cluster?")
+            raise SystemExit
 
-    cpu_df = pd.DataFrame(cpu_values, columns=cpu_columns, dtype=float)
+    cpu_df = pd.DataFrame(
+        cpu_values,
+        columns=cpu_columns,
+        dtype=int
+    )
     memory_df = pd.DataFrame(
-        memory_values, columns=memory_columns, dtype=float)
+        memory_values,
+        columns=memory_columns,
+        dtype=int
+    )
 
     return cpu_df, memory_df
 
@@ -354,13 +435,14 @@ def make_aggregate_dataframes(
     return cpu_requests_df, cpu_limits_df, memory_requests_df, memory_limits_df
 
 
-def get_recs(domain: str, test: bool = False) -> tuple:
+def get_recs(cluster: str, domain: str, namespace: str) -> dict:
     """Calls most of the functions to get recommendations.
     Calls other functions to generate a nested_dict containing all recommendations.
 
     Args:
+        cluster: The cluster to get resources from.
         domain: The domain name where Goldilocks is installed.
-        test: Passed to get_clusters() to only return the first cluster.
+        namespace: The namespace to get resource requests for.
 
     Raises:
         Nothing.
@@ -368,33 +450,28 @@ def get_recs(domain: str, test: bool = False) -> tuple:
     Returns:
         A tuple with the cluster list and a nested_dict.
     """
-    cluster_namespaces = {}
+
     mega_dict = nested_dict()
-    clusters = get_clusters("prod", test)
 
-    for cluster in clusters:
-        cluster_namespaces[cluster] = get_namespaces(cluster)
+    print(f"Getting recommendations for SOAs in {cluster}/{namespace}")
 
-    for cluster_name, namespace_list in cluster_namespaces.items():
-        print(f"Getting data from {cluster_name}")
-        for namespace in namespace_list:
-            html = get_html(cluster_name, domain, namespace)
-            soup_dict = make_soup(html)
-            for soa, recs in soup_dict.items():
-                mega_dict[cluster_name][namespace][soa] = recs
+    html = get_html(cluster, domain, namespace)
+    soup_dict = make_soup(html)
+    for soa, recs in soup_dict.items():
+        mega_dict[cluster][namespace][soa] = recs
 
-    return clusters, mega_dict
+    return mega_dict
 
 
 def make_resource_dict(
-    cpu_req_df: pd.DataFrame,
-    mem_req_df: pd.DataFrame,
-    cpu_lim_df: pd.DataFrame,
-    mem_lim_df: pd.DataFrame,
+    cpu_req_tuple_df: tuple,
+    mem_req_tuple_df: tuple,
+    cpu_lim_tuple_df: tuple,
+    mem_lim_tuple_df: tuple,
     soa: str,
     lim_stat: str,
     req_stat: str,
-    mib: bool
+    gib: bool
 ) -> dict:
     """Makes a dict to be converted to YAML.
     Gets {stat} value from the dataframe (e.g. max),
@@ -407,7 +484,7 @@ def make_resource_dict(
         mem_lim_df: A dataframe containing memory limits.
         soa: A str of the SOA's name to select.
         {lim,req}stat: A str of {min, max, mean, median} to select that stat.
-        mib: From args.mib - indicates whether to use Gi[B] or Mi[B].
+        gib: From args.gib - indicates whether to use Gi[B] or Mi[B].
 
     Raises:
         System Exit if KeyError, indicative of a problem retreiving or parsing the data.
@@ -416,39 +493,59 @@ def make_resource_dict(
         A dict of resources.
     """
 
-    if args.mib:
-        unit = "Mi"
-    else:
+    if args.gib:
         unit = "Gi"
+    else:
+        unit = "Mi"
+
+    cpu_req_df = cpu_req_tuple_df[0]
+    mem_req_df = mem_req_tuple_df[0]
+    cpu_lim_df = cpu_lim_tuple_df[0]
+    mem_lim_df = mem_lim_tuple_df[0]
+    rec_cpu_req_df = cpu_req_tuple_df[1]
+    rec_mem_req_df = mem_req_tuple_df[1]
+    rec_cpu_lim_df = cpu_lim_tuple_df[1]
+    rec_mem_lim_df = mem_lim_tuple_df[1]
 
     try:
         soa_dict = nested_dict()
-        soa_dict["resources"]["limits"]["cpu"] = f"{cpu_lim_df[('millicores'), lim_stat][soa]}m"
-        soa_dict["resources"]["limits"]["memory"] = f"{mem_lim_df[('size', lim_stat)][soa]}{unit}"
-        soa_dict["resources"]["requests"]["cpu"] = f"{cpu_req_df[('millicores', req_stat)][soa]}m"
-        soa_dict["resources"]["requests"]["memory"] = f"{mem_req_df[('size', req_stat)][soa]}{unit}"
+        soa_dict["resources"]["current"]["limits"]["cpu"] = f"{cpu_lim_df[('millicores'), lim_stat][soa]}m"
+        soa_dict["resources"]["current"]["limits"]["memory"] = f"{mem_lim_df[('size', lim_stat)][soa]}{unit}"
+        soa_dict["resources"]["current"]["requests"]["cpu"] = f"{cpu_req_df[('millicores', req_stat)][soa]}m"
+        soa_dict["resources"]["current"]["requests"]["memory"] = f"{mem_req_df[('size', req_stat)][soa]}{unit}"
+        soa_dict["resources"]["recommendations"]["limits"]["cpu"] = f"{rec_cpu_lim_df[('millicores'), lim_stat][soa]}m"
+        soa_dict["resources"]["recommendations"]["limits"]["memory"] = f"{rec_mem_lim_df[('size', lim_stat)][soa]}{unit}"
+        soa_dict["resources"]["recommendations"]["requests"]["cpu"] = f"{rec_cpu_req_df[('millicores', req_stat)][soa]}m"
+        soa_dict["resources"]["recommendations"]["requests"]["memory"] = f"{rec_mem_req_df[('size', req_stat)][soa]}{unit}"
     except KeyError as e:
-        print(f"Error finding {soa} - {e}")
-        raise SystemExit
+       print(f"Error finding {soa} - {e}")
 
-    return soa_dict.to_dict()
+    return soa_dict
 
 
-def make_yaml_resource_block(soa: dict) -> str:
+def make_yaml_resource_block(namespace: str, soa: dict) -> str:
     """Makes a formatted yaml resource block.
     Takes an input dict generated from dataframes,
     and formats it as below for inclusion in a Helm chart.
 
     resources:
-      requests:
-        cpu: 812m
-        memory: 4506M
-      limits:
-        cpu: 1151m
-        memory: 4999M
+      current:
+        limits:
+          cpu: 1151m
+          memory: 4999Mi
+        requests:
+          cpu: 812m
+          memory: 4506Mi
+      recommendations:
+        limits:
+          cpu: 45m
+          memory: 300Mi
+        requests:
+          cpu: 15m
+          memory: 150Mi
 
     Args:
-        soa: A dict containing CPU and memory values.
+        soa: A dict containing current and recommended CPU & Memory values.
 
     Raises:
         Nothing.
@@ -457,19 +554,19 @@ def make_yaml_resource_block(soa: dict) -> str:
         A formatted string in YAML format.
     """
 
-    return f"\n{yaml.dump(soa)}\n"
+    return f"\n{yaml.dump({namespace: soa})}\n"
 
 
-def make_yaml_dump(
-    soas: pd.core.indexes.base.Index,
-    cpu_agg_req_df: pd.DataFrame,
-    mem_agg_req_df: pd.DataFrame,
-    cpu_agg_lim_df: pd.DataFrame,
-    mem_agg_lim_df: pd.DataFrame,
-    mib: bool,
+def build_resources_dict(
+    soas: tuple,
+    cpu_agg_req_df: tuple,
+    mem_agg_req_df: tuple,
+    cpu_agg_lim_df: tuple,
+    mem_agg_lim_df: tuple,
+    gib: bool,
     stat_lim: str = "max",
     stat_req: str = "median"
-) -> str:
+) -> dict:
     """Creates a single string of recommendations per SOA.
     Creates a single formatted string - not necessarily to YAML spec,
     since there are multiple SOAs on the same page - for manual input.
@@ -477,7 +574,7 @@ def make_yaml_dump(
     Args:
         soas: The index from an aggregate dataframe, which is a list of SOAs.
         {cpu,mem}_agg_{req,lim}_df: Dataframes containing aggregates for resources.
-        mib: From args.mib - indicates whether to use Gi[B] or Mi[B].
+        gib: From args.gib - indicates whether to use Gi[B] or Mi[B].
         stat_{lim,req}: A str of {min, max, mean, median} to select that stat.
 
 
@@ -485,13 +582,13 @@ def make_yaml_dump(
         Nothing.
 
     Returns:
-        A formatted string of all recommendations.
+        A dictionary of all current and recommended values for resources.
     """
 
     soa_recs = {}
 
-    for soa in soas:
-        soa_rec = make_resource_dict(
+    for soa in soas[0]:
+        soa_nested_dict = make_resource_dict(
             cpu_agg_req_df,
             mem_agg_req_df,
             cpu_agg_lim_df,
@@ -499,49 +596,144 @@ def make_yaml_dump(
             soa,
             stat_lim,
             stat_req,
-            mib
+            gib,
         )
+        soa_rec = soa_nested_dict.to_dict()
         soa_recs[soa] = soa_rec
 
-    return make_yaml_resource_block(soa_recs)
+    return soa_recs
+
+
+def export_csv(filename: str, namespace, resources: dict):
+    """Exports current, recommended and the difference in resources in a CSV file.
+    Exports current, recommended by Goldilocks and the difference in resources in
+    a CSV file that can easily be imported into spreadsheets or other data analysis
+    tools to graph the data.
+
+    Args:
+        filename: The filename that will be used to create the CSV file.
+        resources: The current and recommended resources by Goldilocks.
+
+    Raises:
+        Nothing.
+
+    Returns:
+        Nothing.
+    """
+
+    if args.gib:
+        unit = "Gi"
+    else:
+        unit = "Mi"
+
+    headers = [
+        "namespace",
+        "soa",
+        "Current [CPU] (m)",
+        "Recommendations [CPU] (m)",
+        "Difference [CPU] (m)",
+        f"Current [Memory] ({unit})",
+        f"Recommendations [Memory] ({unit})",
+        f"Difference [Memory] ({unit})"
+    ]
+
+    with open(f"{filename}.csv", 'a') as outp:
+        dw = csv.DictWriter(outp, delimiter=',', fieldnames=headers)
+        dw.writeheader()
+
+        for k, v in resources.items():
+            try:
+                cur_cpu = v['resources']['current']['requests']['cpu'].strip("m")
+                rec_cpu = v['resources']['recommendations']['requests']['cpu'].strip("m")
+                diff_cpu = rec_cpu - cur_cpu
+                cur_mem = v['resources']['current']['requests']['memory'].strip("Mi")
+                rec_mem = v['resources']['recommendations']['requests']['memory'].strip("Mi")
+                diff_memory = rec_memory - cur_memory
+            except:
+                rec_cpu = 0
+                cur_cpu = 0
+                diff_cpu = 0
+                rec_mem = 0
+                cur_mem = 0
+                diff_memory = 0
+
+            outp.write(f"{namespace},{k},{cur_cpu},{rec_cpu},{diff_cpu},{cur_mem},{rec_mem},{diff_memory}\n")
+
 
 
 if __name__ == "__main__":
     args = setup_args()
 
     print("Initializing...")
-    clusters, mega_dict = get_recs(args.domain, args.test)
-    useful_mega_dict = make_useful_dict(mega_dict)
+    namespaces = get_namespaces(args.cluster, args.namespace)
 
-    cpu_lim_df, mem_lim_df = make_dataframe(
-        useful_mega_dict,
-        "limits",
-        clusters,
-        args.mib
-    )
-    cpu_req_df, mem_req_df = make_dataframe(
-        useful_mega_dict,
-        "requests",
-        clusters,
-        args.mib
-    )
-    cpu_agg_req_df, cpu_agg_lim_df, mem_agg_req_df, mem_agg_lim_df = make_aggregate_dataframes(
-        cpu_req_df,
-        mem_req_df,
-        cpu_lim_df,
-        mem_lim_df
-    )
+    for namespace in namespaces:
+        mega_dict = get_recs(args.cluster, args.domain, namespace)
+        useful_mega_dict = make_useful_dict(mega_dict, "html")
 
-    recs = make_yaml_dump(
-        cpu_agg_req_df.index,
-        cpu_agg_req_df,
-        mem_agg_req_df,
-        cpu_agg_lim_df,
-        mem_agg_lim_df,
-        args.mib,
-        args.limit,
-        args.request
-    )
+        rec_cpu_lim_df, rec_mem_lim_df = make_dataframe(
+            useful_mega_dict,
+            "limits",
+            args.cluster,
+            args.gib
+        )
 
-    with open(args.file, "w") as f:
-        f.write(recs)
+        rec_cpu_req_df, rec_mem_req_df = make_dataframe(
+            useful_mega_dict,
+            "requests",
+            args.cluster,
+            args.gib
+        )
+
+        rec_cpu_agg_req_df, rec_cpu_agg_lim_df, rec_mem_agg_req_df, rec_mem_agg_lim_df = make_aggregate_dataframes(
+            rec_cpu_req_df,
+            rec_mem_req_df,
+            rec_cpu_lim_df,
+            rec_mem_lim_df
+        )
+
+        mega_dict = get_current_resources(args.cluster, namespace)
+        useful_mega_dict = make_useful_dict(mega_dict, "k8s")
+
+        cpu_lim_df, mem_lim_df = make_dataframe(
+            useful_mega_dict,
+            "limits",
+            args.cluster,
+            args.gib
+        )
+        cpu_req_df, mem_req_df = make_dataframe(
+            useful_mega_dict,
+            "requests",
+            args.cluster,
+            args.gib
+        )
+
+        cpu_agg_req_df, cpu_agg_lim_df, mem_agg_req_df, mem_agg_lim_df = make_aggregate_dataframes(
+            cpu_req_df,
+            mem_req_df,
+            cpu_lim_df,
+            mem_lim_df
+        )
+
+        resources = build_resources_dict(
+            (cpu_agg_req_df.index,rec_cpu_agg_req_df.index),
+            (cpu_agg_req_df, rec_cpu_agg_req_df),
+            (mem_agg_req_df,rec_mem_agg_req_df),
+            (cpu_agg_lim_df,rec_cpu_agg_lim_df),
+            (mem_agg_lim_df,rec_mem_agg_lim_df),
+            args.gib,
+            args.limit,
+            args.request
+        )
+        yaml_dump = make_yaml_resource_block(namespace, resources)
+
+        filename = args.file
+        if filename is None:
+            filename = namespace
+
+        with open(f"{filename}.yaml", "a") as f:
+            f.write(yaml_dump)
+
+        if args.csv:
+            export_csv(filename, namespace, resources)
+


### PR DESCRIPTION
## Changes

### Scrape current resource requests and limits
I have extended the tool to scrape current resource requests and limits which can be useful for data analysis. My team and I have realised it is useful to find the biggest difference between the recommendation and the actual usage to reduce our cost of hosting the clusters.

### Export data in CSV format
Added a flag to export the data in a CSV format which makes it easy to import the data in tools for data analysis. This helps to graph the data where a cluster hosts hundreds of apps and find the ones with the highest cost and potential savings. 